### PR TITLE
記事をビルドする CI を追加

### DIFF
--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: setup environment
         run: |
-          apt update -y && apt install -y make
+          apk add make bash
           make setup
 
       - name: get branch info

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -17,7 +17,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: setup environment
-        run: make setup
+        run: |
+          apt update -y && apt install -y make
+          make setup
 
       - name: get branch info
         id: branch_info

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -1,0 +1,46 @@
+name: Articles Branch CI
+
+on:
+  push:
+    branches: ["articles/**"]
+  pull_request:
+    branches: ["articles/**"]
+
+jobs:
+  build-article:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/typst/typst:latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup environment
+        run: make setup
+
+      - name: get branch info
+        id: branch_info
+        shell: bash
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          if [[ "$BRANCH" =~ ^articles/([^/]+)$ ]]; then
+            ARTICLE_NAME="${BASH_REMATCH[1]}"
+            echo "match=true" >> $GITHUB_OUTPUT
+            echo "article_name=$ARTICLE_NAME" >> $GITHUB_OUTPUT
+          fi
+
+      - name: build article
+        if: steps.branch_info.outputs.match
+        run: |
+          cd "${{ steps.branch_info.outputs.branch }}"
+          make build
+
+      - name: upload artifact
+        if: steps.branch_info.outputs.match
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.branch_info.outputs.article_name }}.pdf
+          path: ${{ steps.branch_info.outputs.branch }}/main.pdf
+          retention-days: 3

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -7,7 +7,7 @@ on:
     branches: ["articles/**"]
 
 jobs:
-  build-article:
+  compile-article:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/typst/typst:latest
@@ -33,11 +33,11 @@ jobs:
             echo "article_name=$ARTICLE_NAME" >> $GITHUB_OUTPUT
           fi
 
-      - name: build article
+      - name: compile article
         if: steps.branch_info.outputs.match
         run: |
           cd "${{ steps.branch_info.outputs.branch }}"
-          make build
+          make compile
 
       - name: upload artifact
         if: steps.branch_info.outputs.match

--- a/.github/workflows/articles_branch.yaml
+++ b/.github/workflows/articles_branch.yaml
@@ -7,7 +7,7 @@ on:
     branches: ["articles/**"]
 
 jobs:
-  compile-article:
+  make-article:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/typst/typst:latest

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -1,4 +1,4 @@
-name: Articles Branch CI
+name: Main Branch CI
 
 on:
   push:

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: setup environment
         run: |
-          apt update -y && apt install -y make
+          apk add make
           make setup
 
       - name: build article

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -1,0 +1,31 @@
+name: Articles Branch CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-article:
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/typst/typst:latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup environment
+        run: make setup
+
+      - name: build article
+        if: steps.branch_info.outputs.match
+        run: make build
+
+      - name: upload artifact
+        if: steps.branch_info.outputs.match
+        uses: actions/upload-artifact@v4
+        with:
+          name: main.pdf
+          path: main.pdf
+          retention-days: 3

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: setup environment
         run: |
-          apk add make
+          apk add make bash
           make setup
 
       - name: build article

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -21,11 +21,9 @@ jobs:
           make setup
 
       - name: build article
-        if: steps.branch_info.outputs.match
         run: make build
 
-      - name: upload artifact
-        if: steps.branch_info.outputs.match
+      - name: upload 
         uses: actions/upload-artifact@v4
         with:
           name: main.pdf

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build-article:
+  compile-article:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/typst/typst:latest
@@ -20,8 +20,8 @@ jobs:
           apk add make bash
           make setup
 
-      - name: build article
-        run: make build
+      - name: compile article
+        run: make compile
 
       - name: upload 
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -16,7 +16,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: setup environment
-        run: make setup
+        run: |
+          apt update -y && apt install -y make
+          make setup
 
       - name: build article
         if: steps.branch_info.outputs.match

--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  compile-article:
+  make-article:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/typst/typst:latest

--- a/articles/hinagata/main.typ
+++ b/articles/hinagata/main.typ
@@ -8,7 +8,7 @@
 
 #show: article.with(
   title: "記事を執筆しよう",
-  author: "情報 太郎"
+  author: "情報 太郎",
 )
 
 = 環境を準備する
@@ -34,7 +34,7 @@ $ make setup
 記事全体をコンパイルする場合は、記事のGitリポジトリのルートで次のコマンドを実行します。
 
 ```
-$ make build
+$ make compile
 ```
 
 #ovalbox[main.pdf] が作成されれば成功です。
@@ -51,7 +51,7 @@ $ make build
 #include "articles/hinagata/main.typ"
 ```
 
-そして、@compile に従って `make build` を実行し、記事が適切にコンパイルされることを確認します。
+そして、@compile に従って `make compile` を実行し、記事が適切にコンパイルされることを確認します。
 
 = Gitサーバにpushする
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,6 @@ for name in "${!missing_fonts[@]}"; do
   wget -q ${missing_fonts[$name]} -P fonts/
 done
 
-unzip -q "fonts/*.zip" -d fonts/
+unzip -q fonts/*.zip -d fonts/
 
 rm -rf fonts/*.zip

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,6 @@ for name in "${!missing_fonts[@]}"; do
   wget -q ${missing_fonts[$name]} -P fonts/
 done
 
-unzip -q fonts/*.zip -d fonts/
+unzip -q 'fonts/*.zip' -d fonts/
 
 rm -rf fonts/*.zip


### PR DESCRIPTION
`fonts/*` をキャッシュしたが、そんなに早くならなかったので撤回
いずれは `apk add` もキャッシュするか、コンテナイメージに含めてしまってもよいと思う