### PR TITLE
`Makefile`のターゲットに`.PHONY`を追加し雛形の和文・欧文の間のスペースを消去した

### DIFF
--- a/.github/workflows/main_branch.yaml
+++ b/.github/workflows/main_branch.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches-ignore: ["articles/**"]
 
 jobs:
   make-article:

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,22 @@
 TYPST = typst
 
+.PHONY: check
 check:
 	./scripts/list.sh | ./scripts/check.sh
 
+.PHONY: setup
 setup:
 	./scripts/list.sh | ./scripts/install.sh
 
+.PHONY: compile
 compile:
 	$(TYPST) compile --root=. --font-path=fonts main.typ main.pdf
 
+.PHONY: watch
 watch:
 	$(TYPST) watch --root=. --font-path=fonts main.typ main.pdf
 
+.PHONY: clean
 clean:
 	rm -rf *.pdf
 	rm -rf fonts

--- a/articles/hinagata/main.typ
+++ b/articles/hinagata/main.typ
@@ -13,13 +13,13 @@
 
 = 環境を準備する
 
-WORDの記事をコンパイルするにあたって、Typst が必要です。
+WORDの記事をコンパイルするにあたって、Typstが必要です。
 
 - Git #footnote[https://git-scm.com/]
 - Typst #footnote[https://typst.app/]
 - GNU Make #footnote[https://www.gnu.org/software/make/]
 
-記事のリポジトリを Git コマンドなどにより、クローンします。
+記事のリポジトリをGitコマンドなどにより、クローンします。
 その後、記事のGitリポジトリのルートで以下のコマンドを実行します。
 
 ```
@@ -27,7 +27,7 @@ $ make setup
 ```
 
 これでコンパイルに必要なフォントなどがダウンロードされます。
-必要なフォントが入っているかを確認したい場合は、`make check` で確認できます。
+必要なフォントが入っているかを確認したい場合は、`make check`で確認できます。
 
 = コンパイルする <compile>
 
@@ -37,7 +37,7 @@ $ make setup
 $ make compile
 ```
 
-#ovalbox[main.pdf] が作成されれば成功です。
+#ovalbox[main.pdf]が作成されれば成功です。
 
 = 記事を追加する
 
@@ -51,14 +51,14 @@ $ make compile
 #include "articles/hinagata/main.typ"
 ```
 
-そして、@compile に従って `make compile` を実行し、記事が適切にコンパイルされることを確認します。
+そして、#ref(<compile>)に従って`make compile`を実行し、記事が適切にコンパイルされることを確認します。
 
 = Gitサーバにpushする
 
 WORDではかつて伝統あるGitoliteにより管理されていましたが、
 ディスク故障によってGitのデータを失ってからBitbucketへ、そしてGitHubへと移行されました。
 
-まず、WORDのGitHubのOrganizationである https://github.com/WORD-COINS へ参加していない場合は、
+まず、WORDのGitHubのOrganizationである#link("https://github.com/WORD-COINS")へ参加していない場合は、
 GitHubのアカウントを取得した後、編集長や管理者の誰かへ連絡してメンバーに加えてもらいましょう。
 
 GitHubにプッシュする場合は、自分の編集を行った適当なブランチを次のコマンドでプッシュします。
@@ -72,7 +72,7 @@ $ git push origin articles/my_article
 == 「文 編集部」の変更・削除
 
 編集部以外のメンバーが執筆する場合「文 編集部」は必要ありません。
-これは、記事の `main.typ` の `#show: article.with` の箇所を以下のように変更すれば消すことができます。
+これは、記事の`main.typ`の`#show: article.with`の箇所を以下のように変更すれば消すことができます。
 
 ```
 #show: article.with(


### PR DESCRIPTION
### 概要

- `Makefile`のターゲット名（？）がファイルではない場合は`.PHONY`を書いておくとよいらしいので追加した
- `./hinagata/main.typ`には和文・欧文の間にスペースが入っていったり入っていなかったりしていた
    - LaTeXではスペースを入れるのは処理系がやるので入れないのが正しいが、Typstはどっちが正解なのか分からなかった混在はおかしいということで消去した
- その際、リファレンス`@compile`など直後にあるスペースを消したところエラーになってしまったので、`#ref`や`#link`に置き換えた
    - ちなみにLaTeXではたとえば`\hline`といったコントロールシーケンスの直後にあるスペースは無視されることになっているため、スペースを挟むこともできるし、それが嫌な場合は`{\hline}`のようにグループで囲んで和文・欧文の間にスペース入れないことで統一することもできる
- またこのPRのように雛形そのものやスクリプトに変更を加えた際に動くCIがなかったので、 PRのブランチ名が`articles/**`で**ない**場合は`main_branch.yaml`のCIが実行されるようにした