### PR TITLE
数式，画像，表，コードブロックが全体で連番にならないように

### DIFF
--- a/template/article.typ
+++ b/template/article.typ
@@ -43,6 +43,10 @@
   set heading(offset: 1)
 
   counter(footnote).update(0)
+  counter(math.equation).update(0)
+  counter(figure.where(kind: image)).update(0)
+  counter(figure.where(kind: table)).update(0)
+  counter(figure.where(kind: raw)).update(0)
 
   body
 }


### PR DESCRIPTION
#12 と同様ですが，現状はこれらの要素についても連番になるので修正します