### PR TITLE
目次のページ番号のナンバリングを修正

### DIFF
--- a/template/toc.typ
+++ b/template/toc.typ
@@ -9,16 +9,18 @@
 
   let elements = query(heading.where(level: 1, outlined: true))
   for el in elements {
-    let metadatas = query(selector(<author>).after(el.location()))
+    let loc = el.location()
+    let page = numbering(loc.page-numbering(), ..counter(page).at(loc))
+    let metadatas = query(selector(<author>).after(loc))
     let author = metadatas.first().value
-    link(el.location())[
+    link(loc)[
       #block(width: 100%)[
         #el.body
         #box(width: 1fr, repeat[．])
         #text(style: "italic", author)
         #box(width: 2em, inset: (left: 1em))[
           #align(right)[
-            #el.location().page()
+            #page
           ]
         ]
       ]


### PR DESCRIPTION
目次で実際のページ番号を正しくナンバリングするようにした

<img width="728" height="248" alt="image" src="https://github.com/user-attachments/assets/5bfcd184-be7a-4bc9-857a-aeac7e3cec7b" />
<img width="618" height="871" alt="image" src="https://github.com/user-attachments/assets/c0396fa8-93b6-4147-9579-a79d18f7042a" />
<img width="617" height="869" alt="image" src="https://github.com/user-attachments/assets/73278dbb-b8e6-4943-8c88-f58f5a342690" />
